### PR TITLE
Wrong event error handling

### DIFF
--- a/lib/src/bridge/js_function_util.dart
+++ b/lib/src/bridge/js_function_util.dart
@@ -53,12 +53,13 @@ class JsUtil {
       TelegramEventType.fullscreenChanged => (event.eventHandler as void Function()).toJS,
       TelegramEventType.fullscreenFailed => (FullScreenFailedResultJSObject result) {
         event.eventHandler(result.error.toDart);
-      }.toJS,
+        }.toJS,
       TelegramEventType.deviceOrientationStarted => (event.eventHandler as void Function()).toJS,
       TelegramEventType.deviceOrientationStopped => (event.eventHandler as void Function()).toJS,
       TelegramEventType.deviceOrientationChanged => (event.eventHandler as void Function()).toJS,
-      TelegramEventType.deviceOrientationFailed =>
-        (event.eventHandler as void Function(String error)).toJS,
+      TelegramEventType.deviceOrientationFailed => (DeviceOrientationFailedResultJSObject result) {
+        event.eventHandler(result.error.toDart);
+        }.toJS,
       TelegramEventType.homeScreenAdded => (event.eventHandler as void Function()).toJS,
       TelegramEventType.homeScreenChecked => (HomeScreenCheckedResultJSObject result) {
           event.eventHandler(result.status.toDart);
@@ -72,17 +73,21 @@ class JsUtil {
       TelegramEventType.gyroscopeStarted => (event.eventHandler as void Function()).toJS,
       TelegramEventType.gyroscopeStopped => (event.eventHandler as void Function()).toJS,
       TelegramEventType.gyroscopeChanged => (event.eventHandler as void Function()).toJS,
-      TelegramEventType.gyroscopeFailed => (event.eventHandler as void Function(String error)).toJS,
+      TelegramEventType.gyroscopeFailed => (GyroscopeFailedResultJSObject result) {
+          event.eventHandler(result.error.toDart);
+        }.toJS,
       TelegramEventType.locationManagerUpdated => (event.eventHandler as void Function()).toJS,
       TelegramEventType.locationRequested => (LocationDataJSObject payload) {
           event.eventHandler.call(LocationData.from(payload));
         }.toJS,
       TelegramEventType.shareMessageSent => (event.eventHandler as void Function()).toJS,
-      TelegramEventType.shareMessageFailed =>
-        (event.eventHandler as void Function(String error)).toJS,
+      TelegramEventType.shareMessageFailed => (ShareMessageFailedResultJSObject result) {
+          event.eventHandler(result.error.toDart);
+        }.toJS,
       TelegramEventType.emojiStatusSet => (event.eventHandler as void Function()).toJS,
-      TelegramEventType.emojiStatusFailed =>
-        (event.eventHandler as void Function(String error)).toJS,
+      TelegramEventType.emojiStatusFailed => (EmojiStatusFailedResultJSObject result) {
+        event.eventHandler(result.error.toDart);
+        }.toJS,
       TelegramEventType.emojiStatusAccessRequested =>
         (event.eventHandler as void Function(String status)).toJS,
       TelegramEventType.fileDownloadRequested =>

--- a/lib/src/bridge/js_function_util.dart
+++ b/lib/src/bridge/js_function_util.dart
@@ -51,8 +51,9 @@ class JsUtil {
           event.eventHandler(BiometricTokenUpdatedPayload(payload.isUpdated.toDart));
         }.toJS,
       TelegramEventType.fullscreenChanged => (event.eventHandler as void Function()).toJS,
-      TelegramEventType.fullscreenFailed =>
-        (event.eventHandler as void Function(String error)).toJS,
+      TelegramEventType.fullscreenFailed => (FullScreenFailedResultJSObject result) {
+        event.eventHandler(result.error.toDart);
+      }.toJS,
       TelegramEventType.deviceOrientationStarted => (event.eventHandler as void Function()).toJS,
       TelegramEventType.deviceOrientationStopped => (event.eventHandler as void Function()).toJS,
       TelegramEventType.deviceOrientationChanged => (event.eventHandler as void Function()).toJS,

--- a/lib/src/flutter/events/device_orientation_failed_event.dart
+++ b/lib/src/flutter/events/device_orientation_failed_event.dart
@@ -7,8 +7,5 @@ part of '../../../telegram_web_app.dart';
 /// **UNSUPPORTED** – Device orientation tracking is not supported on this device or platform.
 class DeviceOrientationFailedEvent extends TelegramEvent {
   DeviceOrientationFailedEvent(void Function(String error) eventHandler)
-      : super(TelegramEventType.deviceOrientationFailed,
-            (DeviceOrientationFailedResultJSObject result) {
-          eventHandler(result.error.toDart);
-        });
+      : super(TelegramEventType.deviceOrientationFailed, eventHandler);
 }

--- a/lib/src/flutter/events/emoji/emoji_status_failed_event.dart
+++ b/lib/src/flutter/events/emoji/emoji_status_failed_event.dart
@@ -14,7 +14,5 @@ part of '../../../../telegram_web_app.dart';
 /// - **UNKNOWN_ERROR** – An unknown error occurred.
 class EmojiStatusFailedEvent extends TelegramEvent {
   EmojiStatusFailedEvent(void Function(String error) eventHandler)
-      : super(TelegramEventType.emojiStatusFailed, (EmojiStatusFailedResultJSObject result) {
-          eventHandler(result.error.toDart);
-        });
+      : super(TelegramEventType.emojiStatusFailed, eventHandler);
 }

--- a/lib/src/flutter/events/fullscreen_failed_event.dart
+++ b/lib/src/flutter/events/fullscreen_failed_event.dart
@@ -10,7 +10,5 @@ part of '../../../telegram_web_app.dart';
 /// **ALREADY_FULLSCREEN** – The Mini App is already in fullscreen mode.
 class FullscreenFailedEvent extends TelegramEvent {
   FullscreenFailedEvent(void Function(String error) eventHandler)
-      : super(TelegramEventType.fullscreenFailed, (FullScreenFailedResultJSObject result) {
-          eventHandler(result.error.toDart);
-        });
+      : super(TelegramEventType.fullscreenFailed, eventHandler);
 }

--- a/lib/src/flutter/events/gyroscope/gyroscope_failed_event.dart
+++ b/lib/src/flutter/events/gyroscope/gyroscope_failed_event.dart
@@ -8,7 +8,5 @@ part of '../../../../telegram_web_app.dart';
 /// **UNSUPPORTED** – Gyroscope tracking is not supported on this device or platform.
 class GyroscopeFailedEvent extends TelegramEvent {
   GyroscopeFailedEvent(void Function(String error) eventHandler)
-      : super(TelegramEventType.gyroscopeFailed, (GyroscopeFailedResultJSObject result) {
-          eventHandler(result.error.toDart);
-        });
+      : super(TelegramEventType.gyroscopeFailed, eventHandler);
 }

--- a/lib/src/flutter/events/share_message_failed_event.dart
+++ b/lib/src/flutter/events/share_message_failed_event.dart
@@ -12,7 +12,5 @@ part of '../../../telegram_web_app.dart';
 /// UNKNOWN_ERROR – An unknown error occurred.
 class ShareMessageFailedEvent extends TelegramEvent {
   ShareMessageFailedEvent(void Function(String error) eventHandler)
-      : super(TelegramEventType.shareMessageFailed, (ShareMessageFailedResultJSObject result) {
-          eventHandler(result.error.toDart);
-        });
+      : super(TelegramEventType.shareMessageFailed, eventHandler);
 }


### PR DESCRIPTION
For example:

Closure 'FullscreenFailedEvent_closure': type '(JSObject) => Null' is not a subtype of type '(String) => void'